### PR TITLE
Implement multimodal request support for Gemini API (#2)

### DIFF
--- a/src/ChatAIze.GenerativeCS.csproj
+++ b/src/ChatAIze.GenerativeCS.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Title>Generative CS</Title>
     <Product>Generative CS</Product>
-    <Version>0.14.2</Version>
+    <Version>0.15.0</Version>
     <Company>ChatAIze</Company>
     <Authors>Marcel Kwiatkowski</Authors>
     <Copyright>© ChatAIze 2025</Copyright>
@@ -25,9 +25,12 @@
     <SuppressSymbolPackageFormatValidation>true</SuppressSymbolPackageFormatValidation>
     <Description>
       Generative AI library for .NET 9.0 with built-in OpenAI ChatGPT and Google Gemini API clients
-      and support for C# function calling via reflection.
+      and support for C# function calling via reflection. Now includes multimodal support for Gemini,
+      allowing text, PDF, DOC, video, audio, and image file processing.
       Features:
       - Chat Completion
+      - Gemini Multimodal Requests (text with files)
+      - Gemini File Management (upload, get, list, delete)
       - Response Streaming
       - Text Embedding
       - Text-to-Speech
@@ -49,21 +52,21 @@
       chatgpt-api client co co-pilot complete completion completion-generator completion-provider
       completions completions-generator completions-provider conversation conversational
       conversational-ai copilot cs csharp davinci dialog dotnet dotnet-core embedding
-      embedding-model embeddings embeddings-model function function-calling functional
+      embedding-model embeddings embeddings-model file-data file-upload file-uri function function-calling functional
       functional-gpt functions functions-calling gemini gemini-api gemini-api-client gemini-client
       gemini-pro gemini-pro-api gemini-pro-api-client gemini-pro-client generation generative-ai
       generative-cs generator google google-bard google-gemini google-gemini-pro
       google-gemini-pro-api google-gemini-pro-api-client google-gemini-pro-client gpt gpt-3 gpt-4
-      gpt-function gpt-functions gpt3 gpt4 kernel language language-model learning library llama llm
+      gpt-function gpt-functions gpt3 gpt4 image kernel language language-model learning library llama llm
       machine machine-learning method method-calling methods methods-calling microsot ml model
-      moderation natural natural-language-processing nlp open-ai open-ai-api open-ai-client openai
-      openai-api openai-api-client openai-client pilot pro processing prompt provider reflection
+      moderation multi-modal multimodal natural natural-language-processing nlp open-ai open-ai-api open-ai-client openai
+      openai-api openai-api-client openai-client pdf pilot pro processing prompt provider reflection
       respond response response-completion response-generation rest rest-api restful restful-api
       robot sdk search semantic sound speech speech-to-text stream streaming synthesis text
       text-completion text-embedding text-embeddings text-generation text-synthesis text-to-speech
       token transcript transcription transformer transformer-model transformers transformers-model
-      translation translator tts turbo vector vector-embedding vector-embeddings vector-search
-      vertex virtual virtual-assistant voice whisper whisper-api wrapper
+      translation translator tts txt turbo vector vector-embedding vector-embeddings vector-search
+      vertex video virtual virtual-assistant voice whisper whisper-api wrapper
     </PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Extensions/GeminiClientExtension.cs
+++ b/src/Extensions/GeminiClientExtension.cs
@@ -2,6 +2,7 @@ using ChatAIze.Abstractions.Chat;
 using ChatAIze.GenerativeCS.Clients;
 using ChatAIze.GenerativeCS.Models;
 using ChatAIze.GenerativeCS.Options.Gemini;
+using ChatAIze.GenerativeCS.Providers.Gemini;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace ChatAIze.GenerativeCS.Extensions;
@@ -28,6 +29,13 @@ public static class GeminiClientExtension
         _ = services.AddHttpClient<GeminiClient>();
         _ = services.AddSingleton<GeminiClient<TChat, TMessage, TFunctionCall, TFunctionResult>>();
         _ = services.AddSingleton<GeminiClient>();
+
+        // Register IFileService to be resolved from the GeminiClient's Files property
+        _ = services.AddSingleton<IFileService>(sp => 
+        {
+            var client = sp.GetRequiredService<GeminiClient<TChat, TMessage, TFunctionCall, TFunctionResult>>();
+            return client.Files; 
+        });
 
         return services;
     }

--- a/src/Models/ChatContentPart.cs
+++ b/src/Models/ChatContentPart.cs
@@ -1,0 +1,46 @@
+using System.Text.Json.Serialization;
+
+namespace ChatAIze.GenerativeCS.Models
+{
+    /// <summary>
+    /// Represents a part of a chat message content, which can be text, file data, etc.
+    /// </summary>
+    public interface IChatContentPart { }
+
+    public class TextPart : IChatContentPart
+    {
+        [JsonPropertyName("text")]
+        public string Text { get; set; }
+
+        public TextPart(string text)
+        {
+            Text = text;
+        }
+    }
+
+    public class FileDataPart : IChatContentPart
+    {
+        [JsonPropertyName("file_data")]
+        public FileDataSource FileData { get; set; }
+
+        public FileDataPart(FileDataSource fileData)
+        {
+            FileData = fileData;
+        }
+    }
+
+    public class FileDataSource
+    {
+        [JsonPropertyName("mime_type")]
+        public string MimeType { get; set; }
+
+        [JsonPropertyName("file_uri")]
+        public string FileUri { get; set; }
+
+        public FileDataSource(string mimeType, string fileUri)
+        {
+            MimeType = mimeType;
+            FileUri = fileUri;
+        }
+    }
+} 

--- a/src/Models/Gemini/GeminiFile.cs
+++ b/src/Models/Gemini/GeminiFile.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace ChatAIze.GenerativeCS.Models.Gemini
+{
+    public class GeminiFile
+    {
+        [JsonPropertyName("name")]
+        required public string Name { get; set; }
+
+        [JsonPropertyName("uri")]
+        required public string Uri { get; set; }
+
+        [JsonPropertyName("mime_type")]
+        required public string MimeType { get; set; }
+
+        [JsonPropertyName("size_bytes")]
+        public long? SizeBytes { get; set; }
+
+        [JsonPropertyName("create_time")]
+        public DateTime? CreateTime { get; set; }
+
+        [JsonPropertyName("update_time")]
+        public DateTime? UpdateTime { get; set; }
+
+        [JsonPropertyName("expiration_time")]
+        public DateTime? ExpirationTime { get; set; }
+
+        [JsonPropertyName("sha256_hash")]
+        public string? Sha256Hash { get; set; }
+
+        [JsonPropertyName("display_name")]
+        public string? DisplayName { get; set; }
+
+        [JsonPropertyName("state")]
+        public string? State { get; set; } // e.g., "ACTIVE", "PROCESSING"
+    }
+} 

--- a/src/Models/Gemini/GeminiFileUploadRequest.cs
+++ b/src/Models/Gemini/GeminiFileUploadRequest.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace ChatAIze.GenerativeCS.Models.Gemini
+{
+    public class FileMetadata
+    {
+        [JsonPropertyName("display_name")]
+        required public string DisplayName { get; set; }
+    }
+
+    public class GeminiFileUploadRequest
+    {
+        [JsonPropertyName("file")]
+        required public FileMetadata File { get; set; }
+    }
+} 

--- a/src/Models/Gemini/GeminiListFilesResponse.cs
+++ b/src/Models/Gemini/GeminiListFilesResponse.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ChatAIze.GenerativeCS.Models.Gemini
+{
+    public class GeminiListFilesResponse
+    {
+        [JsonPropertyName("files")]
+        public List<GeminiFile> Files { get; set; } = new();
+
+        [JsonPropertyName("nextPageToken")]
+        public string? NextPageToken { get; set; }
+    }
+} 

--- a/src/Options/Gemini/GeminiOptions.cs
+++ b/src/Options/Gemini/GeminiOptions.cs
@@ -1,0 +1,25 @@
+namespace ChatAIze.GenerativeCS.Options.Gemini
+{
+    public class GeminiOptions
+    {
+        public string? ApiKey { get; set; }
+        public string? ModelId { get; set; } // e.g., "gemini-1.5-flash"
+
+        private string _fileApiBaseUrl = "https://generativelanguage.googleapis.com/upload/v1beta";
+        public string FileApiBaseUrl 
+        {
+            get => _fileApiBaseUrl;
+            set => _fileApiBaseUrl = value.TrimEnd('/');
+        }
+
+        private string _generativeApiBaseUrl = "https://generativelanguage.googleapis.com/v1beta";
+        public string GenerativeApiBaseUrl
+        {
+            get => _generativeApiBaseUrl;
+            set => _generativeApiBaseUrl = value.TrimEnd('/');
+        }
+        
+        // Default timeout for HTTP requests, in seconds
+        public int DefaultTimeoutSeconds { get; set; } = 100;
+    }
+} 

--- a/src/Providers/Gemini/FileService.cs
+++ b/src/Providers/Gemini/FileService.cs
@@ -1,0 +1,155 @@
+using ChatAIze.GenerativeCS.Models.Gemini;
+using ChatAIze.GenerativeCS.Options.Gemini;
+using Microsoft.Extensions.Options;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json; 
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text.Json.Serialization;
+
+namespace ChatAIze.GenerativeCS.Providers.Gemini
+{
+    public class FileService : IFileService // Renamed from GeminiFileServiceProvider, implements IFileService
+    {
+        private readonly HttpClient _httpClient;
+        private readonly GeminiOptions _options;
+        // private const string GeminiApiKeyHeader = "X-Goog-Api-Key"; // Not used, API key is in query
+
+        public FileService(HttpClient httpClient, IOptions<GeminiOptions> options) // Constructor name matches new class name
+        {
+            _httpClient = httpClient;
+            _options = options.Value;
+        }
+
+        public async Task<GeminiFile?> UploadFileAsync(string filePath, string mimeType, string? displayName = null, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(_options.ApiKey))
+                throw new InvalidOperationException("API key is not configured for Gemini.");
+
+            displayName ??= Path.GetFileName(filePath);
+            using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
+            return await UploadFileAsync(fileStream, Path.GetFileName(filePath), mimeType, displayName, cancellationToken);
+        }
+
+        public async Task<GeminiFile?> UploadFileAsync(Stream stream, string fileName, string mimeType, string? displayName = null, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(_options.ApiKey))
+                throw new InvalidOperationException("API key is not configured for Gemini.");
+
+            displayName ??= fileName;
+            long fileSize = stream.Length;
+
+            var initialRequestUrl = $"{_options.FileApiBaseUrl}/files?key={_options.ApiKey}";
+
+            var initialRequest = new HttpRequestMessage(HttpMethod.Post, initialRequestUrl);
+            initialRequest.Headers.Add("X-Goog-Upload-Protocol", "resumable");
+            initialRequest.Headers.Add("X-Goog-Upload-Command", "start");
+            initialRequest.Headers.Add("X-Goog-Upload-Header-Content-Length", fileSize.ToString());
+            initialRequest.Headers.Add("X-Goog-Upload-Header-Content-Type", mimeType);
+            
+            var uploadRequestData = new GeminiFileUploadRequest { File = new Models.Gemini.FileMetadata { DisplayName = displayName } };
+            initialRequest.Content = JsonContent.Create(uploadRequestData, options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            initialRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+            HttpResponseMessage initialResponse = await _httpClient.SendAsync(initialRequest, cancellationToken);
+            if (!initialResponse.IsSuccessStatusCode)
+            {
+                var errorContent = await initialResponse.Content.ReadAsStringAsync(cancellationToken);
+                throw new HttpRequestException($"Failed to initiate file upload. Status: {initialResponse.StatusCode}. Response: {errorContent}");
+            }
+
+            if (!initialResponse.Headers.TryGetValues("X-Goog-Upload-URL", out var uploadUrlValues) || !Uri.TryCreate(uploadUrlValues.FirstOrDefault(), UriKind.Absolute, out var uploadUrl))
+            {
+                throw new HttpRequestException("Failed to get upload URL from response headers.");
+            }
+
+            var uploadContent = new StreamContent(stream);
+            uploadContent.Headers.ContentType = new MediaTypeHeaderValue(mimeType);
+
+            var uploadRequest = new HttpRequestMessage(HttpMethod.Post, uploadUrl);
+            uploadRequest.Headers.Add("X-Goog-Upload-Command", "upload, finalize");
+            uploadRequest.Headers.Add("X-Goog-Upload-Offset", "0");
+            uploadRequest.Content = uploadContent;
+
+            HttpResponseMessage uploadResponse = await _httpClient.SendAsync(uploadRequest, cancellationToken);
+
+            if (!uploadResponse.IsSuccessStatusCode)
+            {
+                var errorContent = await uploadResponse.Content.ReadAsStringAsync(cancellationToken);
+                throw new HttpRequestException($"Failed to upload file content. Status: {uploadResponse.StatusCode}. Response: {errorContent}");
+            }
+
+            var fileUploadWrapper = await uploadResponse.Content.ReadFromJsonAsync<GeminiFileUploadResponseWrapper>(cancellationToken: cancellationToken);
+            return fileUploadWrapper?.File;
+        }
+
+        public async Task<GeminiFile?> GetFileAsync(string name, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(_options.ApiKey))
+                throw new InvalidOperationException("API key is not configured for Gemini.");
+
+            var requestUrl = $"{_options.FileApiBaseUrl}/{name.TrimStart('/')}?key={_options.ApiKey}";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+
+            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                if (response.StatusCode == System.Net.HttpStatusCode.NotFound) return null;
+                var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                throw new HttpRequestException($"Failed to get file metadata. Status: {response.StatusCode}. Response: {errorContent}");
+            }
+            var fileWrapper = await response.Content.ReadFromJsonAsync<GeminiFileUploadResponseWrapper>(cancellationToken: cancellationToken);
+            return fileWrapper?.File;
+        }
+
+        public async Task<GeminiListFilesResponse?> ListFilesAsync(int pageSize = 1000, string? pageToken = null, CancellationToken cancellationToken = default)
+        {
+             if (string.IsNullOrWhiteSpace(_options.ApiKey))
+                throw new InvalidOperationException("API key is not configured for Gemini.");
+
+            var requestUrl = $"{_options.FileApiBaseUrl}/files?key={_options.ApiKey}&pageSize={pageSize}";
+            if (!string.IsNullOrEmpty(pageToken))
+            {
+                requestUrl += $"&pageToken={pageToken}";
+            }
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+
+            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                throw new HttpRequestException($"Failed to list files. Status: {response.StatusCode}. Response: {errorContent}");
+            }
+            return await response.Content.ReadFromJsonAsync<GeminiListFilesResponse>(cancellationToken: cancellationToken);
+        }
+
+        public async Task<bool> DeleteFileAsync(string name, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(_options.ApiKey))
+                throw new InvalidOperationException("API key is not configured for Gemini.");
+
+            var requestUrl = $"{_options.FileApiBaseUrl}/{name.TrimStart('/')}?key={_options.ApiKey}";
+            var request = new HttpRequestMessage(HttpMethod.Delete, requestUrl);
+
+            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+            if (response.IsSuccessStatusCode || response.StatusCode == System.Net.HttpStatusCode.NoContent)
+            {
+                return true;
+            }
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound) return false;
+            
+            // var errorContent = await response.Content.ReadAsStringAsync(cancellationToken); // Don't read if already returned true/false
+            return false;
+        }
+
+        private class GeminiFileUploadResponseWrapper
+        {
+            [JsonPropertyName("file")]
+            required public GeminiFile File { get; set; }
+        }
+    }
+} 

--- a/src/Providers/Gemini/IFileService.cs
+++ b/src/Providers/Gemini/IFileService.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ChatAIze.GenerativeCS.Models.Gemini;
+
+namespace ChatAIze.GenerativeCS.Providers.Gemini
+{
+    public interface IFileService // Renamed from IGeminiFileServiceProvider
+    {
+        Task<GeminiFile?> UploadFileAsync(string filePath, string mimeType, string? displayName = null, CancellationToken cancellationToken = default);
+        Task<GeminiFile?> UploadFileAsync(System.IO.Stream stream, string fileName, string mimeType, string? displayName = null, CancellationToken cancellationToken = default);
+        Task<GeminiFile?> GetFileAsync(string name, CancellationToken cancellationToken = default);
+        Task<GeminiListFilesResponse?> ListFilesAsync(int pageSize = 1000, string? pageToken = null, CancellationToken cancellationToken = default);
+        Task<bool> DeleteFileAsync(string name, CancellationToken cancellationToken = default);
+    }
+} 


### PR DESCRIPTION
This pull request introduces multimodal support for the Google Gemini API within the `ChatAIze.GenerativeCS` library, addressing issue #2. Users can now send requests combining text with various file types (PDF, DOC, TXT, images, audio, video).

**Key Changes Implemented:**

*   **Gemini File Service (`FileService.cs`, `IFileService.cs`):**
    *   Added a new service to handle interactions with the Gemini Files API.
    *   Supports uploading files (via path or stream), retrieving file metadata, listing uploaded files, and deleting files.
    *   Follows the resumable upload protocol as per Gemini API documentation.
    *   File service and interface names (`FileService`, `IFileService`) are aligned with existing provider naming conventions (e.g., `ChatCompletion.cs`).

*   **Enhanced Chat Message Structure (`ChatMessage.cs`, `ChatContentPart.cs`):**
    *   `ChatMessage.cs` now uses an `ICollection<IChatContentPart> Parts` property to hold different content types within a single message.
    *   Introduced `IChatContentPart` interface and concrete `TextPart` and `FileDataPart` classes.
    *   `FileDataPart` encapsulates `FileDataSource` (MIME type and file URI) for referencing uploaded files.
    *   The existing `ChatMessage.Content` property has been marked `[Obsolete]` and now acts as a getter/setter for the first `TextPart` in the `Parts` collection to maintain backward compatibility.

*   **Updated Gemini Chat Provider (`ChatCompletion.cs`):**
    *   The `CreateChatCompletionRequest` method now iterates through `message.Parts`.
    *   Correctly serializes `TextPart` and `FileDataPart` (including `mime_type` and `file_uri`) into the JSON payload for the Gemini API's `generateContent` endpoint.
    *   Ensures an empty text part is added if a message has no other content parts, as required by the Gemini API.
    *   Obsolete warnings for `ChatMessage.Content` usage (for backward compatibility fallback) have been suppressed with `#pragma`.

*   **Client and DI Integration (`GeminiClient.cs`, `GeminiClientExtension.cs`):**
    *   `GeminiClient.cs` now instantiates and exposes an `IFileService` through a public `Files` property.
    *   Dependency Injection in `GeminiClientExtension.cs` has been updated to register `IFileService` as a singleton, resolving its instance from the `GeminiClient.Files` property. This ensures a consistent `IFileService` instance is used.

*   **Model Updates (`Models/Gemini/`)**
    *   Added `GeminiFile.cs`, `GeminiFileUploadRequest.cs`, `GeminiListFilesResponse.cs` to represent data structures for the Gemini Files API.
    *   Addressed nullable warnings (CS8618) in these models by using the `required` modifier for non-nullable properties expected from the API and initializing collections.

*   **Documentation & Packaging:**
    *   Updated `README.md` with a new section explaining how to use the multimodal features, including accessing `IFileService`, uploading files, and sending chat messages with file references.
    *   Incremented the library version in `ChatAIze.GenerativeCS.csproj` to `0.15.0`.
    *   Updated package description and tags in the `.csproj` file to reflect the new multimodal capabilities.

**How to Test:**
1.  Obtain an instance of `GeminiClient`.
2.  Access the file service via `geminiClient.Files`.
3.  Upload a supported file (e.g., PDF, PNG) using `fileService.UploadFileAsync(...)`.
4.  Create a `Chat` object and add a `ChatMessage`.
5.  To the `ChatMessage.Parts` collection, add a `TextPart` and a `FileDataPart` using the `MimeType` and `Uri` from the uploaded file.
6.  Call `geminiClient.CompleteAsync(chat)` and observe the model's response, which should consider the content of the uploaded file.

**Future Considerations (Not in this PR):**
*   Adding higher-level convenience wrappers in `GeminiClient.cs` to simplify the process of sending a message with a local file (e.g., a method that handles both upload and message creation).

This implementation adheres to the existing coding patterns and architectural style of the library.

Fixes #2
